### PR TITLE
Caching module

### DIFF
--- a/pirlib/cache.py
+++ b/pirlib/cache.py
@@ -1,16 +1,23 @@
-#%%
-import os
 import shutil
 from io import BytesIO
 from pathlib import Path
+from zipfile import ZipFile
 
 from diskcache import Cache
 
-CACHE_DIR = "./tmp/cache"
-#%%
+CACHE_DIR = "../tmp/cache"
 
 
 def cache_directory(dir_path: Path, cache_key: str) -> bool:
+    """Caches a given directory with the given key.
+
+    :param dir_path: The directory to be cached.
+    :type dir_path: Path
+    :param cache_key: An key that will be used to retreive the cached directiry.
+    :type cache_key: str
+    :return: True if caching was a success, False if the key already exists.
+    :rtype: bool
+    """
     # Zip the contents of the directory.
     zipped_dir = shutil.make_archive(str(dir_path.parts[-1]), "zip", dir_path)
 
@@ -30,4 +37,29 @@ def cache_directory(dir_path: Path, cache_key: str) -> bool:
     return status
 
 
-#%%
+def fetch_directory(dir_path: Path, cache_key: str) -> bool:
+    """Retrieves a cached directory. Contents of the existing directory
+    will get overwritten if they share the same file name with that of the
+    files in the cache.
+
+    :param dir_path: The directory which needs to be fetched. The directory
+    will be created if it doesn't already exist.
+    :type dir_path: Path
+    :param cache_key: The cache key which uniquely identifies the directory.
+    :type cache_key: str
+    :return: True if the directory was retrived successfully, False otherwise.
+    :rtype: bool
+    """
+    # Retreive the zip bytestream if key exists.
+    with Cache(CACHE_DIR) as cache_ref:
+        if cache_key in cache_ref:
+            zipped_stream = cache_ref.get(cache_key)
+        else:
+            return False
+
+    # Create a ZipFile object from the bystream.
+    with ZipFile(zipped_stream, mode="r") as zipped_dir:
+        # Extract the ziped directory in the provided path.
+        zipped_dir.extractall(path=dir_path)
+
+    return True

--- a/pirlib/cache.py
+++ b/pirlib/cache.py
@@ -1,0 +1,33 @@
+#%%
+import os
+import shutil
+from io import BytesIO
+from pathlib import Path
+
+from diskcache import Cache
+
+CACHE_DIR = "./tmp/cache"
+#%%
+
+
+def cache_directory(dir_path: Path, cache_key: str) -> bool:
+    # Zip the contents of the directory.
+    zipped_dir = shutil.make_archive(str(dir_path.parts[-1]), "zip", dir_path)
+
+    # Cache the zip file.
+    with Cache(CACHE_DIR) as cache_ref:
+        # Read the zip file as bytestream.
+        with open(zipped_dir, "rb") as f:
+            dir_bytes = BytesIO(f.read())
+
+        # Add the zipped stream to the cache.
+        status = cache_ref.add(cache_key, dir_bytes)
+
+    # Delete the zipped file.
+    Path(zipped_dir).unlink()
+
+    # Return the status of cache add operation.
+    return status
+
+
+#%%

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@
 
 
 import os
-import setuptools
 
+import setuptools
 
 if __name__ == "__main__":
     setuptools.setup(
@@ -31,10 +31,6 @@ if __name__ == "__main__":
             "Operating System :: POSIX :: Linux",
         ],
         packages=setuptools.find_packages(include=["pirlib", "pirlib.*"]),
-        python_requires='>=3.8',
-        install_requires=[
-            "dacite>=1.6",
-            "pyyaml>=6.0",
-            "typeguard>=2.13",
-        ],
+        python_requires=">=3.8",
+        install_requires=["dacite>=1.6", "pyyaml>=6.0", "typeguard>=2.13", "diskcache==5.4.0"],
     )


### PR DESCRIPTION
This PR introduces the following:
- A module that contains the functions required for caching and cache fetching.

Subsequent PRs related to TuunV2 would make use of this module to enable caching for tasks and functions.

This module is at a very nascent stage, hence please ignore the hard coded value of `CACHE_DIR`.  Going forward, this can be accepted from the user via env vars.